### PR TITLE
Add Google Search Console verification

### DIFF
--- a/gatsby-ssr.tsx
+++ b/gatsby-ssr.tsx
@@ -3,6 +3,11 @@ import * as React from "react"
 
 export const onRenderBody: GatsbySSR["onRenderBody"] = ({ setHeadComponents }) => {
   setHeadComponents([
+    <meta
+      name="google-site-verification"
+      content="9isK6Cy-UKzUynqAIKFHJhvvUUtbwrdusrV1XCrB1Qk"
+      key="googleSiteVerification"
+    />,
     <link
       rel="preload"
       href="/fonts/work-sans.var.woff2"


### PR DESCRIPTION
Adds the Google Search Console verification meta tag so the refreshed portfolio can be indexed and its sitemap submitted.\n\nValidated with `npm run typecheck` and `npm run build`.